### PR TITLE
Allow prettyNumber to round to 0 decimal places

### DIFF
--- a/lib/written.js
+++ b/lib/written.js
@@ -280,7 +280,7 @@
       delimiter = ",";
     }
     if (decimals == null) {
-      decimals = 0;
+      decimals = -1;
     }
     if (dot == null) {
       dot = ".";
@@ -289,7 +289,7 @@
       decimals = delimiter;
     }
     n = parseNumber(n);
-    if (decimals > 0) {
+    if (decimals >= 0) {
       n = n.toFixed(decimals);
     }
     if (dot) {


### PR DESCRIPTION
To reproduce: `written.prettyNumber(0.814, 0)`
Expected output: `1`
Current output: `0.814`

This minor change allows rounding to 0 decimal places.

(Note, written.min.js needs updating too, but I got stuck on the grunt workflow)