### PR TITLE
Allow prettyNumber to round to 0 decimal places

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,10 +424,10 @@ w.parseNumber("some 44,000 participants")        # 44000
 ```
 
 
-      prettyNumber = (n, delimiter = ",", decimals = 0, dot = ".") ->
+      prettyNumber = (n, delimiter = ",", decimals = -1, dot = ".") ->
         decimals = delimiter if typeof delimiter is "number"
         n = parseNumber(n)
-        n = n.toFixed(decimals) if decimals > 0
+        n = n.toFixed(decimals) if decimals >= 0
         n = n.toString().replace(".", dot) if dot
         [ int, frac ] = n.toString().split(dot)
         [ int.replace(/\B(?=(\d{3})+(?!\d))/g, delimiter), frac ]

--- a/lib/written.js
+++ b/lib/written.js
@@ -280,7 +280,7 @@
       delimiter = ",";
     }
     if (decimals == null) {
-      decimals = -1;
+      decimals = 0;
     }
     if (dot == null) {
       dot = ".";
@@ -289,7 +289,7 @@
       decimals = delimiter;
     }
     n = parseNumber(n);
-    if (decimals >= 0) {
+    if (decimals > 0) {
       n = n.toFixed(decimals);
     }
     if (dot) {

--- a/lib/written.js
+++ b/lib/written.js
@@ -280,7 +280,7 @@
       delimiter = ",";
     }
     if (decimals == null) {
-      decimals = 0;
+      decimals = -1;
     }
     if (dot == null) {
       dot = ".";
@@ -289,7 +289,7 @@
       decimals = delimiter;
     }
     n = parseNumber(n);
-    if (decimals > 0) {
+    if (decimals >= 0) {
       n = n.toFixed(decimals);
     }
     if (dot) {


### PR DESCRIPTION
To reproduce: `written.prettyNumber(0.814, 0)`
Expected output: `1`
Current output: `0.814`

Fixed by a tiny change to the default `decimals` prop and associated value check in `prettyNumber()`